### PR TITLE
parse content before creating carlo instance

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -19,6 +19,9 @@ const main = async () => {
       ? process.argv[2]
       : path.resolve(process.argv[2] || 'README.md')
 
+  // Parse content before creating carlo instance
+  const content = await parse(filePath)
+
   const app = await carlo.launch({
     userDataDir: tmpDir
   })
@@ -29,7 +32,6 @@ const main = async () => {
   const event = new Events()
   await app.exposeObject('event', event)
 
-  const content = await parse(filePath)
   await app.exposeFunction('parse', _ => {
     return {
       content,


### PR DESCRIPTION
So it won't pop-up empty window if there are errors on parsing.