### PR TITLE
Minor edits to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 ![](https://badgen.net/badge//chrome?icon=chrome)
 
 
-> Koy is a markdown previewer powered by [carlo](https://github.com/GoogleChromeLabs/carlo).
+> Koy is a markdown previewer powered by [Carlo](https://github.com/GoogleChromeLabs/carlo).
 
 ![preview](https://user-images.githubusercontent.com/914329/47839466-c95b6d80-dded-11e8-835c-259bacea7a86.png)
 
 ## Features
 
-- Read `README.md` in current working directory by default.
+- View `README.md` in current working directory by default.
 - Render markdown in GitHub style.
-- Live preview, automatically re-render on file changes.
+- Live preview and automatic re-rendering of file changes.
 
 ## Install
 


### PR DESCRIPTION
Capitalized Carlo on first sentence. Carlo is capitalized on the original repository, so it's best to capitalize to keep it consistent.
Changed "Read README.md" to "View README.md." Using "read" as a verb before README.md sounds redundant, so it's best to change it to a verb with a similar meaning.
Rephrased "live preview..." bullet point. The original sentence was unclear, so it's rephrased for clarity.

Fixes #10 